### PR TITLE
Support for autoboxing

### DIFF
--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -145,9 +145,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>asm</groupId>
+      <groupId>org.ow2.asm</groupId>
       <artifactId>asm-debug-all</artifactId>
-      <version>3.2</version>
+      <version>4.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/ClassAnnotationInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/ClassAnnotationInjector.java
@@ -23,19 +23,19 @@
  */
 package com.infradna.tool.bridge_method_injector;
 
-import org.objectweb.asm.ClassAdapter;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Adds class annotations.
  *
  * @author Kohsuke Kawaguchi
  */
-abstract class ClassAnnotationInjector extends ClassAdapter {
+abstract class ClassAnnotationInjector extends ClassVisitor {
     ClassAnnotationInjector(ClassVisitor cv) {
-        super(cv);
+        super(Opcodes.ASM4, cv);
     }
 
     private boolean emitted = false;

--- a/injector/src/test/client/Main.java
+++ b/injector/src/test/client/Main.java
@@ -3,6 +3,8 @@ public class Main {
         // invocation of void method. verify that it runs without error
         Foo.hello();
         Foo.hello2();
+        Foo.unbox();
+        Foo.box();
 
         Object o = new Foo().getMessage();
         assertEquals(args[0],o);

--- a/injector/src/test/v1/Foo.java
+++ b/injector/src/test/v1/Foo.java
@@ -24,4 +24,8 @@ public class Foo implements IFoo {
     public static void hello() {}
 
     public static void hello2() {}
+    
+    public static int unbox() {return Integer.MIN_VALUE;}
+    
+    public static int box() {return Integer.MAX_VALUE;}
 }

--- a/injector/src/test/v2/Foo.java
+++ b/injector/src/test/v2/Foo.java
@@ -33,4 +33,14 @@ public class Foo implements IFoo {
     public static String hello2() {
         return "hello2";
     }
+    
+    @WithBridgeMethods(value=int.class, castRequired=true)
+    public static Integer unbox() {
+        return Integer.MIN_VALUE;
+    }
+    
+    @WithBridgeMethods(value=Integer.class)
+    public static int box() {
+        return Integer.MAX_VALUE;
+    }
 }


### PR DESCRIPTION
- Updated to 4.2 version of ASM.
- Preliminary support for autoboxing.

I encountered a weird NPE from type.getInternalName() while using primitives so my initial reaction was to raise the version to 4.2 which of course did not fix the issue. Further digging around revealed that autoboxing requires bytecode level support and that GeneratorAdapter will be a way around the bug(?)

There is a GeneratorAdapter (at least in 4.2 version) that has unbox/box methods for autoboxing implementation. I replaced couple of lines at SyntheticMethod to get the new tests working and my own use case resolved but I assume that a more robust solution would be needed.
