### PR TITLE
Add jdk8 synthetics case

### DIFF
--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -47,6 +47,7 @@
                 <mkdir dir="target/test-classes/v1" />
                 <mkdir dir="target/test-classes/v2" />
                 <mkdir dir="target/test-classes/client" />
+                <mkdir dir="target/test-classes/synthetics" />
 
                 <!-- basic sanity. unmodified client and v1 should work as expected -->
                 <javac source="1.6" target="1.6" srcdir="src/test/v1" destdir="target/test-classes/v1" />
@@ -78,6 +79,20 @@
                     <pathelement path="target/test-classes/v2" />
                     <pathelement path="target/test-classes/client" />
                   </classpath>
+                </java>
+
+                <!-- compile synthetics -->
+                <javac source="1.6" target="1.6" srcdir="src/test/synthetics" destdir="target/test-classes/synthetics" classpath="${maven.compile.classpath}">
+                  <compilerarg value="-XprintProcessorInfo" />
+                  <classpath>
+                    <pathelement path="target/classes" />
+                    <path refid="maven.compile.classpath" />
+                  </classpath>
+                </javac>
+
+                <!-- post process synthetics -->
+                <java classname="com.infradna.tool.bridge_method_injector.MethodInjector" args="${project.basedir}/target/test-classes/synthetics" failonerror="true">
+                  <classpath refid="maven.compile.classpath" />
                 </java>
 
                 <!-- was testing source compatibility, but with widening change it won't work anymore -->

--- a/injector/src/test/synthetics/A.java
+++ b/injector/src/test/synthetics/A.java
@@ -1,0 +1,5 @@
+public class A {
+    public Object getProperty() {
+        return null;
+    }
+}

--- a/injector/src/test/synthetics/B.java
+++ b/injector/src/test/synthetics/B.java
@@ -1,0 +1,9 @@
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+
+public class B extends A {
+
+    @WithBridgeMethods(value=String.class,castRequired=true)
+    public CharSequence getProperty() {
+        return null;
+    }
+}


### PR DESCRIPTION
Example case for https://github.com/infradna/bridge-method-injector/issues/4

```
javap injector/target/test-classes/synthetics/B.class 
```

outputs

```
public class B extends A {
  public B();
  public java.lang.CharSequence getProperty();
  public java.lang.Object getProperty();
  public java.lang.String getProperty();
  public java.lang.String getProperty();
}
```

on jdk7

```
public class B extends A {
  public B();
  public java.lang.CharSequence getProperty();
  public java.lang.Object getProperty();
  public java.lang.String getProperty();
}
```
