### PR TITLE
Handle Java 8 source idioms like super calls to interface default methods

### DIFF
--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -50,8 +50,8 @@
                 <mkdir dir="target/test-classes/synthetics" />
 
                 <!-- basic sanity. unmodified client and v1 should work as expected -->
-                <javac source="1.6" target="1.6" srcdir="src/test/v1" destdir="target/test-classes/v1" />
-                <javac source="1.6" target="1.6" srcdir="src/test/client" destdir="target/test-classes/client" classpath="target/test-classes/v1" />
+                <javac source="8" target="8" srcdir="src/test/v1" destdir="target/test-classes/v1" />
+                <javac source="8" target="8" srcdir="src/test/client" destdir="target/test-classes/client" classpath="target/test-classes/v1" />
                 <java classname="Main" args="foo" failonerror="true">
                   <classpath>
                     <pathelement path="target/test-classes/v1" />
@@ -60,7 +60,7 @@
                 </java>
 
                 <!-- compile v2 -->
-                <javac source="1.6" target="1.6" srcdir="src/test/v2" destdir="target/test-classes/v2" classpath="${maven.compile.classpath}">
+                <javac source="8" target="8" srcdir="src/test/v2" destdir="target/test-classes/v2" classpath="${maven.compile.classpath}">
                   <compilerarg value="-XprintProcessorInfo" />
                   <classpath>
                     <pathelement path="target/classes" />
@@ -82,7 +82,7 @@
                 </java>
 
                 <!-- compile synthetics -->
-                <javac source="1.6" target="1.6" srcdir="src/test/synthetics" destdir="target/test-classes/synthetics" classpath="${maven.compile.classpath}">
+                <javac source="8" target="8" srcdir="src/test/synthetics" destdir="target/test-classes/synthetics" classpath="${maven.compile.classpath}">
                   <compilerarg value="-XprintProcessorInfo" />
                   <classpath>
                     <pathelement path="target/classes" />
@@ -98,7 +98,7 @@
                 <!-- was testing source compatibility, but with widening change it won't work anymore -->
                 <!--
                 <mkdir dir="target/test-classes/client-on-v2" />
-                <javac source="1.6" target="1.6" srcdir="src/test/client" destdir="target/test-classes/client-on-v2">
+                <javac source="8" target="8" srcdir="src/test/client" destdir="target/test-classes/client-on-v2">
                   <classpath>
                     <pathelement path="target/test-classes/v2" />
                   </classpath>
@@ -118,7 +118,7 @@
           <dependency>
             <groupId>com.sun</groupId>
             <artifactId>tools</artifactId>
-            <version>1.6</version>
+            <version>1.8</version>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
           </dependency>

--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/ClassAnnotationInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/ClassAnnotationInjector.java
@@ -35,7 +35,7 @@ import org.objectweb.asm.Opcodes;
  */
 abstract class ClassAnnotationInjector extends ClassVisitor {
     ClassAnnotationInjector(ClassVisitor cv) {
-        super(Opcodes.ASM4, cv);
+        super(Opcodes.ASM5, cv);
     }
 
     private boolean emitted = false;

--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
@@ -139,12 +139,12 @@ public class MethodInjector {
       protected List<Type> types = new ArrayList<Type>();
       
       public WithBridgeMethodsAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM4, av);
+        super(Opcodes.ASM5, av);
       }
 
       @Override
       public AnnotationVisitor visitArray(String name) {
-        return new AnnotationVisitor(Opcodes.ASM4, super.visitArray(name)) {
+        return new AnnotationVisitor(Opcodes.ASM5, super.visitArray(name)) {
            
             public void visit(String name, Object value) {
                 if (value instanceof Type) {
@@ -274,7 +274,7 @@ public class MethodInjector {
         }
 
         Transformer(ClassVisitor cv) {
-            super(Opcodes.ASM4, cv);
+            super(Opcodes.ASM5, cv);
         }
 
         @Override
@@ -296,7 +296,7 @@ public class MethodInjector {
         @Override
         public MethodVisitor visitMethod(final int access, final String name, final String mdesc, final String signature, final String[] exceptions) {
             MethodVisitor mv = super.visitMethod(access, name, mdesc, signature, exceptions);
-            return new MethodVisitor(Opcodes.ASM4, mv) {
+            return new MethodVisitor(Opcodes.ASM5, mv) {
                 @Override
                 public AnnotationVisitor visitAnnotation(String adesc, boolean visible) {
                     AnnotationVisitor av = super.visitAnnotation(adesc, visible);

--- a/injector/src/test/client/Main.java
+++ b/injector/src/test/client/Main.java
@@ -27,6 +27,8 @@ public class Main {
         Adapter a = new Adapter();
         assertEquals(1,a.i());
         assertEquals("http://kohsuke.org/",a.o());
+
+        new Adapter.SomeClass().someMethod();
     }
 
     private static void assertEquals(Object expected, Object actual) {

--- a/injector/src/test/v1/Adapter.java
+++ b/injector/src/test/v1/Adapter.java
@@ -1,4 +1,16 @@
 public class Adapter {
     public int i() { return 1; }
     public String o() { return "http://kohsuke.org/"; }
+
+    // Just making sure we do not barf on Java 8 constructs:
+    interface SomeInterface {
+        default void someMethod() {}
+    }
+    static class SomeClass implements SomeInterface {
+        @Override
+        public void someMethod() {
+            SomeInterface.super.someMethod();
+        }
+    }
+
 }

--- a/injector/src/test/v2/Adapter.java
+++ b/injector/src/test/v2/Adapter.java
@@ -17,4 +17,15 @@ public class Adapter {
     private Object _o(URL o, Class type) {
         return o.toString();
     }
+
+    interface SomeInterface {
+        default void someMethod() {}
+    }
+    static class SomeClass implements SomeInterface {
+        @Override
+        public void someMethod() {
+            SomeInterface.super.someMethod();
+        }
+    }
+
 }


### PR DESCRIPTION
Follows up #14 to actually enable new source constructs in the visitors, not merely handle `-target 8` bytecode using `-source 7` idioms.

@reviewbybees