### PR TITLE
Fix failing build, caused by missing dependency

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -16,4 +16,11 @@
       <version>1.4</version>
     </dependency>
   </dependencies>
+  
+  <repositories>
+      <repository>
+          <id>Jenkins-CI</id>
+          <url>http://repo.jenkins-ci.org/releases/</url>
+      </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
The dependency

<dependency>
    <groupId>org.jenkins-ci</groupId>
    <artifactId>annotation-indexer</artifactId>
    <version>1.4</version>
</dependency>

is present on maven central, but the pom refers to

<dependency>
    <groupId>org.jenkins-ci</groupId>
    <artifactId>jenkins</artifactId>
    <version>1.26</version>
</dependency>

as the parent. This causes the build to fail, as maven fails to
resolve all dependencies.

The missing depency is in the Jenkins repository and so I added
that as a repository.

Alternatives:
- Use a different repository as source
- Remove the  Indexed Annotation from WithBridgeMethods annotation and remove the complete dependency