### PR TITLE
Java 11 compatible release

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.infradna.tool</groupId>
     <artifactId>bridge-method-injector-parent</artifactId>
-    <version>1.19-SNAPSHOT</version>
+    <version>1.19</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>bridge-method-annotation</artifactId>

--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -15,6 +15,11 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.6.0</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
 	<version>3.8.1</version>
         <configuration>
@@ -163,8 +168,13 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-debug-all</artifactId>
-      <version>5.2</version>
+      <artifactId>asm</artifactId>
+      <version>9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>9.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -16,9 +16,10 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+	<version>3.8.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.infradna.tool</groupId>
     <artifactId>bridge-method-injector-parent</artifactId>
-    <version>1.19-SNAPSHOT</version>
+    <version>1.19</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>bridge-method-injector</artifactId>

--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/ClassAnnotationInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/ClassAnnotationInjector.java
@@ -35,7 +35,7 @@ import org.objectweb.asm.Opcodes;
  */
 abstract class ClassAnnotationInjector extends ClassVisitor {
     ClassAnnotationInjector(ClassVisitor cv) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM9, cv);
     }
 
     private boolean emitted = false;

--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
@@ -139,12 +139,12 @@ public class MethodInjector {
       protected List<Type> types = new ArrayList<Type>();
       
       public WithBridgeMethodsAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM5, av);
+        super(Opcodes.ASM9, av);
       }
 
       @Override
       public AnnotationVisitor visitArray(String name) {
-        return new AnnotationVisitor(Opcodes.ASM5, super.visitArray(name)) {
+        return new AnnotationVisitor(Opcodes.ASM9, super.visitArray(name)) {
            
             public void visit(String name, Object value) {
                 if (value instanceof Type) {
@@ -284,7 +284,7 @@ public class MethodInjector {
         }
 
         Transformer(ClassVisitor cv) {
-            super(Opcodes.ASM5, cv);
+            super(Opcodes.ASM9, cv);
         }
 
         @Override
@@ -306,7 +306,7 @@ public class MethodInjector {
         @Override
         public MethodVisitor visitMethod(final int access, final String name, final String mdesc, final String signature, final String[] exceptions) {
             MethodVisitor mv = super.visitMethod(access, name, mdesc, signature, exceptions);
-            return new MethodVisitor(Opcodes.ASM5, mv) {
+            return new MethodVisitor(Opcodes.ASM9, mv) {
                 @Override
                 public AnnotationVisitor visitAnnotation(String adesc, boolean visible) {
                     AnnotationVisitor av = super.visitAnnotation(adesc, visible);

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.infradna.tool</groupId>
   <artifactId>bridge-method-injector-parent</artifactId>
-  <version>1.19-SNAPSHOT</version>
+  <version>1.19</version>
   <packaging>pom</packaging>
 
   <name>Bridge Method Injection Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,10 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+	<version>3.8.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -57,6 +58,7 @@
         </configuration>
       </plugin>
     </plugins>
+
     <extensions>
       <extension>
         <groupId>org.jvnet.wagon-svn</groupId>
@@ -65,6 +67,13 @@
       </extension>
     </extensions>
   </build>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 
   <scm>
     <connection>scm:git:git@github.com:infradna/bridge-method-injector.git</connection>
@@ -112,7 +121,7 @@
       </plugin>
     </plugins>
   </reporting>
-  
+
   <profiles>
     <profile>
       <id>release</id>


### PR DESCRIPTION
Closed #18.

In #19 annotation-indexer was updated to 1.12, but repository was
not changed to repo.jenkins-ci.org.

Also bump version from 1.19-SNAPSHOT to 1.19 to prepare next
release iteration.