### PR TITLE
With a new `annotation-indexer` comes a new index location

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
+      <version>1.14</version>
     </dependency>
   </dependencies>
 </project>

--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/ProcessMojo.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/ProcessMojo.java
@@ -50,7 +50,7 @@ public class ProcessMojo extends AbstractMojo {
     private File classesDirectory;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
-        File index = new File(classesDirectory, "META-INF/annotations/" + WithBridgeMethods.class.getName());
+        File index = new File(classesDirectory, "META-INF/services/annotations/" + WithBridgeMethods.class.getName());
         if (!index.exists()) {
             getLog().debug("Skipping because there's no "+index);
             return;


### PR DESCRIPTION
Needed to adapt to https://github.com/jenkinsci/lib-annotation-indexer/pull/10.

Would benefit from an IT using `maven-invoker-plugin`.
